### PR TITLE
[Topic] Bump up `newrelic_rpm` version from `~> 6.12` to `>= 6.12, < 8`

### DIFF
--- a/rails_filters_tracer.gemspec
+++ b/rails_filters_tracer.gemspec
@@ -33,7 +33,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_dependency "rails", "6.0.3"
-  spec.add_dependency "newrelic_rpm", "~> 6.12"
+  spec.add_dependency "newrelic_rpm", ">= 6.12", "<8"
 
   spec.add_development_dependency "pry-byebug"
   spec.add_development_dependency "simplecov-cobertura"


### PR DESCRIPTION
Update the dependency version range of `newrelic_rpm` gem
- from `~> 6.12`
- to `>= 6.12, < 8`

Proof that this bump up is Okay is in https://github.com/kudojp/rails_filters_tracer/pull/4#issuecomment-1051881330.

